### PR TITLE
Update unrealircd-admin.css

### DIFF
--- a/css/unrealircd-admin.css
+++ b/css/unrealircd-admin.css
@@ -240,3 +240,7 @@ body {
 @media (min-width: 577px) and (max-height: 812px) {
   /* CSS rules for landscape screens go here */
 }
+
+.container, .container-fluid, .container-lg, .container-md, .container-sm, .container-xl {
+	width: inherit;
+}


### PR DESCRIPTION
Tested on Firefox: as soon as we are on any page, there is the scrollbar activated at the bottom of page. The div that could pose a problem is the div that contains the nav tag with the "container-fluid" class, the default bootstrap contains a width: 100% and this width when it is removed the scrollbar is removed. This css disables/resets the width. It seems to work pretty well on my Firefox browser.