### PR TITLE
updated to work on apache2

### DIFF
--- a/api/common_api.php
+++ b/api/common_api.php
@@ -56,7 +56,7 @@ function flush_completely()
 	}
 }
 
-flush_completely();
+//flush_completely();
 
 /* Send server-sent events (SSE) message */
 function send_sse($json)


### PR DESCRIPTION
The lists of users and chat rooms... they are not functioning because users.php, for example, does not execute due to it stopping prematurely because of common_api.php. Disabling this, it works fine with Apache2. The same identical issue occurs on two different servers with Apache2: one before December 2023 on CentOS with Cpanel, and the same on Debian 12 with Apache2 as well.